### PR TITLE
Add function to convert a partition to memory Object

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'net.alphatab:alphaTab-android:1.3.0-SNAPSHOT'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/NotesDisplayedActivity.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/NotesDisplayedActivity.kt
@@ -1,0 +1,51 @@
+package com.github.scribeWizTeam.scribewiz
+
+import android.net.Uri
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import alphaTab.AlphaTabView
+import alphaTab.Settings
+import alphaTab.core.ecmaScript.Uint8Array
+import alphaTab.importer.ScoreLoader
+import alphaTab.model.Score
+import alphaTab.synth.PlayerState
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import java.io.ByteArrayOutputStream
+import kotlin.contracts.ExperimentalContracts
+
+
+class NotesDisplayedActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    @ExperimentalContracts //Required by the implementation of the library to work
+    private fun loadInMemoryMusicXML(uri: Uri, settings: Settings?) : Score? {
+        var inMemoryObject : Score? = null
+        try {
+            val fileData = readFileData(uri)
+            inMemoryObject = ScoreLoader.loadScoreFromBytes(fileData, settings)
+            Log.i("AlphaTab", "File loaded: ${inMemoryObject.title}")
+        } catch (e: Exception) {
+            Log.e("AlphaTab", "Failed to load file: $e, ${e.stackTraceToString()}")
+            Toast.makeText(this, "Open File Failed", Toast.LENGTH_LONG).show() //simple feedback in a small popup
+        }
+
+        return inMemoryObject
+    }
+
+    @ExperimentalContracts
+    //Copied-paste from the usage example of alphaTab
+    private fun readFileData(uri: Uri): Uint8Array {
+        val inputStream = contentResolver.openInputStream(uri)
+        inputStream.use {
+            ByteArrayOutputStream().use {
+                inputStream!!.copyTo(it)
+                return Uint8Array(it.toByteArray().asUByteArray())
+            }
+        }
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 rootProject.name = "ScribeWiz"


### PR DESCRIPTION
First about the library added : the URL I added at the end was because this library doesn't exist on the mavenCentral Repository. This is thus the URL of the mirror repository I used. We might possibly in the future want to add this repo. in local.

The two functions I added couldn't really be tested without quite the complications since they create In-Memory Object specific to the library. Since this step will have a direct impact on what will be displayed (It is the data displayed), we'll have no trouble to attain the needed test-coverage when other methods will have been merged.

The second function is copy-pasted, the first one is greatly inspired by another function. Please find those in https://github.com/CoderLine/alphaTabSamplesAndroid in the main Activity.