### PR TITLE
add a note guesser

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,8 +106,11 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    jacoco.includeNoLocationClasses = true
-    jacoco.excludes = ['jdk.internal.*']
+   jacoco.includeNoLocationClasses = true
+   jacoco.excludes = ['jdk.internal.*']
+   testLogging {
+       showStandardStreams = true
+   }
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/transcription/NotesGuesser.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/transcription/NotesGuesser.kt
@@ -1,0 +1,52 @@
+package com.github.scribeWizTeam.scribewiz.transcription
+
+import kotlin.math.*
+
+
+const val SILENT_PITCH = -1
+
+data class Note(val pitch: Int, val startTime: Double, val endTime: Double){
+    val duration = endTime - startTime
+}
+
+class NoteGuesser(val sampleDelay: Double) {
+    // Usage:
+    // - initialize the NoteGuesser with a sampleDelay
+    // - call `add_sample` every sampleDelay seconds with a sampled frequency
+    // - when there is no more samples to process, call `end_guessing`
+    // - you can retrieve the guessed notes at any time in the `notes` attribute
+
+    var time: Double = 0.0
+    var notes: List<Note> = listOf()
+    var currentNote: Note = Note(SILENT_PITCH, 0.0, 0.0)
+
+    fun add_sample(pitchFreq: Double?){
+        val midiPitch = compute_midi_pitch(pitchFreq)
+        if (midiPitch != currentNote.pitch){
+            push_current_note()
+            currentNote = Note(midiPitch, time, time+sampleDelay)
+        }
+        currentNote = Note(currentNote.pitch, currentNote.startTime, time+sampleDelay)
+        time += sampleDelay
+    }
+
+    fun end_guessing(){
+        push_current_note()
+    }
+    
+    private fun push_current_note(){
+        if (currentNote.duration != 0.0){
+            notes += currentNote
+            currentNote = Note(SILENT_PITCH, time, time)
+        }
+    }
+
+    private fun compute_midi_pitch(pitchFreq: Double?): Int {
+        // This formula comes from this website
+        //  https://newt.phys.unsw.edu.au/jw/notes.html
+        if (pitchFreq == null){
+            return SILENT_PITCH
+        }
+        return (12*log2(pitchFreq/440.0)+69).roundToInt()
+    }
+}

--- a/app/src/test/java/com/github/scribeWizTeam/scribewiz/transcription/NoteGuesserTest.kt
+++ b/app/src/test/java/com/github/scribeWizTeam/scribewiz/transcription/NoteGuesserTest.kt
@@ -1,0 +1,74 @@
+package com.github.scribeWizTeam.scribewiz.transcription
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+
+class NoteGuesserTest {
+    @Test
+    fun sequence_of_pure_silence_is_guessed_properly() {
+        val samples: List<Double?> = listOf(
+            null,
+            null,
+            null,
+            null
+        )
+
+        val guesser = NoteGuesser(0.2)
+        for (sample in samples){
+            guesser.add_sample(sample)
+        }
+        guesser.end_guessing()
+
+        assertEquals(1, guesser.notes.size)
+        val silence = guesser.notes.get(0)
+        assertEquals(SILENT_PITCH, silence.pitch)
+        assertEquals(0.8, silence.duration, 0.001)
+    }
+
+    @Test
+    fun sequence_of_3_notes_is_guessed_properly() {
+        val samples: List<Double?> = listOf(
+            // 60 | C4 | 261 Hz
+            261.0,
+            262.0,
+            261.0,
+            260.0,
+            // 55 | G3 | 196 Hz
+            196.0,
+            197.0,
+            196.5,
+            195.2,
+            // 64 | E4 | 329 Hz
+            329.0,
+            330.0,
+            330.3,
+            328.4,
+            327.7,
+            331.9,
+            329.4,
+            325.9,
+        )
+        val expected: List<Pair<Int, Double>> = listOf(
+            Pair(60, 2.0),
+            Pair(55, 2.0),
+            Pair(64, 4.0)
+        )
+
+        val guesser = NoteGuesser(0.5)
+        for (sample in samples){
+            guesser.add_sample(sample)
+        }
+        guesser.end_guessing()
+
+        assertEquals(expected.size, guesser.notes.size)
+        for ((i, exp) in expected.withIndex()){
+            val (midiPitch, duration) = exp
+            val note = guesser.notes.get(i)
+            assertEquals(midiPitch, note.pitch)
+            assertEquals(duration, note.duration, 0.001)
+        }
+            
+    }
+}


### PR DESCRIPTION
The note guesser can convert a sequence of pitches into a sequence of midi-like notes