### PR TITLE
A simple musicxml editor helper function

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -150,6 +150,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="180560001">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="406643713">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/app/src/androidTest/java/com/github/scribeWizTeam/scribewiz/EditorTest.kt
+++ b/app/src/androidTest/java/com/github/scribeWizTeam/scribewiz/EditorTest.kt
@@ -7,28 +7,151 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import com.github.scribeWizTeam.scribewiz.Util.Editor
+import org.junit.Assert
+import java.io.PrintWriter
 
 @RunWith(AndroidJUnit4::class)
 class EditorTest {
 
     private lateinit var inputMusicXMLFile: File
     private lateinit var outputMusicXMLFile: File
+    private lateinit var expectedOutputMusicXMLFile: File
+
+    private fun writeToFile(file: File, content: String) {
+        PrintWriter(file).use { out -> out.print(content) }
+    }
 
     @Before
     fun setUp() {
         inputMusicXMLFile = File.createTempFile("input_music_file", ".musicxml")
         outputMusicXMLFile = File.createTempFile("output_music_file", ".musicxml")
+        expectedOutputMusicXMLFile = File.createTempFile("expected_output_music_file", ".musicxml")
     }
 
     @Test
-    fun testEditNoteInMusicXML() {
-        Editor.editNoteInMusicXML(inputMusicXMLFile, outputMusicXMLFile, 5, "C")
+    fun testEditNoteInMusicXML_EmptyInput() {
+        val inputXMLContent = ""
+        writeToFile(inputMusicXMLFile, inputXMLContent)
 
+        Editor.editNoteInMusicXML(inputMusicXMLFile, outputMusicXMLFile, 5, "G")
+        Assert.assertEquals("", outputMusicXMLFile.readText())
     }
+
+    @Test
+    fun testEditNoteInMusicXML_NoteNotFound() {
+        val inputXMLContent = """
+        <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+        <score>
+            <note>
+                <pitch>
+                    <step>A</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>B</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>C</step>
+                </pitch>
+            </note>
+        </score>
+    """.trimIndent()
+        writeToFile(inputMusicXMLFile, inputXMLContent)
+
+        Editor.editNoteInMusicXML(outputMusicXMLFile, inputMusicXMLFile, 5, "G")
+
+        val expectedNotes = getNotes(inputXMLContent)
+        val actualNotes = getNotes(outputMusicXMLFile.readText())
+
+        Assert.assertEquals(expectedNotes, actualNotes)
+    }
+
+    @Test
+    fun testEditNoteInMusicXML_ValidInput() {
+        val inputXMLContent = """
+        <?xml version="1.0"?>
+        <score>
+            <note>
+                <pitch>
+                    <step>A</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>B</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>C</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>D</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>E</step>
+                </pitch>
+            </note>
+        </score>
+    """.trimIndent()
+        writeToFile(inputMusicXMLFile, inputXMLContent)
+
+        val expectedOutputXMLContent = """
+        <?xml version="1.0"?>
+        <score>
+            <note>
+                <pitch>
+                    <step>A</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>B</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>C</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>D</step>
+                </pitch>
+            </note>
+            <note>
+                <pitch>
+                    <step>G</step>
+                </pitch>
+            </note>
+        </score>
+    """.trimIndent()
+
+        Editor.editNoteInMusicXML(inputMusicXMLFile, outputMusicXMLFile, 5, "G")
+
+        val expectedNotes = getNotes(expectedOutputXMLContent)
+        val actualNotes = getNotes(outputMusicXMLFile.readText())
+
+        Assert.assertEquals(expectedNotes, actualNotes)
+    }
+
+    private fun getNotes(xmlContent: String): List<String> {
+        val notePattern = "<note>.*?</note>".toRegex()
+        return notePattern.findAll(xmlContent).map { it.value }.toList()
+    }
+
 
     @After
     fun tearDown() {
         inputMusicXMLFile.delete()
         outputMusicXMLFile.delete()
+        expectedOutputMusicXMLFile.delete()
     }
 }

--- a/app/src/androidTest/java/com/github/scribeWizTeam/scribewiz/EditorTest.kt
+++ b/app/src/androidTest/java/com/github/scribeWizTeam/scribewiz/EditorTest.kt
@@ -1,0 +1,34 @@
+package com.github.scribeWizTeam.scribewiz
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import com.github.scribeWizTeam.scribewiz.Util.Editor
+
+@RunWith(AndroidJUnit4::class)
+class EditorTest {
+
+    private lateinit var inputMusicXMLFile: File
+    private lateinit var outputMusicXMLFile: File
+
+    @Before
+    fun setUp() {
+        inputMusicXMLFile = File.createTempFile("input_music_file", ".musicxml")
+        outputMusicXMLFile = File.createTempFile("output_music_file", ".musicxml")
+    }
+
+    @Test
+    fun testEditNoteInMusicXML() {
+        Editor.editNoteInMusicXML(inputMusicXMLFile, outputMusicXMLFile, 5, "C")
+
+    }
+
+    @After
+    fun tearDown() {
+        inputMusicXMLFile.delete()
+        outputMusicXMLFile.delete()
+    }
+}

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/Util/Editor.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/Util/Editor.kt
@@ -1,0 +1,67 @@
+package com.github.scribeWizTeam.scribewiz.Util
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+class Editor {
+
+    companion object {
+        fun editNoteInMusicXML(outputFile: File, inputFile: File, noteLocation: Int, newNote: String) {
+            val parserFactory = XmlPullParserFactory.newInstance()
+            val parser = parserFactory.newPullParser()
+            val inputStream = FileInputStream(inputFile)
+            parser.setInput(inputStream, null)
+
+            val xmlSerializer = Xml.newSerializer()
+            val outputStream = FileOutputStream(outputFile)
+            xmlSerializer.setOutput(outputStream, "UTF-8")
+            xmlSerializer.startDocument(null, true)
+
+            var eventType = parser.eventType
+            var currentNoteLocation = 0
+
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                when (eventType) {
+                    XmlPullParser.START_TAG -> {
+                        val tagName = parser.name
+                        xmlSerializer.startTag(null, tagName)
+
+                        for (i in 0 until parser.attributeCount) {
+                            xmlSerializer.attribute(
+                                null,
+                                parser.getAttributeName(i),
+                                parser.getAttributeValue(i)
+                            )
+                        }
+
+                        if (tagName == "note") {
+                            currentNoteLocation++
+                        }
+
+                        if (tagName == "step" && currentNoteLocation == noteLocation) {
+                            xmlSerializer.text(newNote)
+                            eventType = parser.next() // Skip the original note text
+                        }
+                    }
+                    XmlPullParser.END_TAG -> {
+                        xmlSerializer.endTag(null, parser.name)
+                    }
+                    XmlPullParser.TEXT -> {
+                        xmlSerializer.text(parser.text)
+                    }
+                }
+                eventType = parser.next()
+            }
+
+            xmlSerializer.endDocument()
+            inputStream.close()
+            outputStream.close()
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/Util/Editor.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/Util/Editor.kt
@@ -3,6 +3,7 @@ package com.github.scribeWizTeam.scribewiz.Util
 import android.util.Xml
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
+import org.xmlpull.v1.XmlSerializer
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -10,56 +11,87 @@ import java.io.FileOutputStream
 class Editor {
 
     companion object {
+        // Function to edit a note at a specific location in a MusicXML file.
         fun editNoteInMusicXML(outputFile: File, inputFile: File, noteLocation: Int, newNote: String) {
+            // Initialize XmlPullParser for parsing the input MusicXML file.
             val parserFactory = XmlPullParserFactory.newInstance()
             val parser = parserFactory.newPullParser()
             val inputStream = FileInputStream(inputFile)
             parser.setInput(inputStream, null)
 
+            // Initialize XmlSerializer for writing the modified content to the output MusicXML file.
             val xmlSerializer = Xml.newSerializer()
             val outputStream = FileOutputStream(outputFile)
             xmlSerializer.setOutput(outputStream, "UTF-8")
             xmlSerializer.startDocument(null, true)
 
+            // Variable to keep track of the current note location in the input MusicXML file.
             var eventType = parser.eventType
             var currentNoteLocation = 0
 
-            while (eventType != XmlPullParser.END_DOCUMENT) {
-                when (eventType) {
-                    XmlPullParser.START_TAG -> {
-                        val tagName = parser.name
-                        xmlSerializer.startTag(null, tagName)
+            // Loop through the input file's XML content until reaching the end of the document, and write the note at the desired location.
+            loopXMLDocument(eventType, parser, xmlSerializer, currentNoteLocation, noteLocation, newNote)
 
-                        for (i in 0 until parser.attributeCount) {
-                            xmlSerializer.attribute(
-                                null,
-                                parser.getAttributeName(i),
-                                parser.getAttributeValue(i)
-                            )
-                        }
-
-                        if (tagName == "note") {
-                            currentNoteLocation++
-                        }
-
-                        if (tagName == "step" && currentNoteLocation == noteLocation) {
-                            xmlSerializer.text(newNote)
-                            eventType = parser.next() // Skip the original note text
-                        }
-                    }
-                    XmlPullParser.END_TAG -> {
-                        xmlSerializer.endTag(null, parser.name)
-                    }
-                    XmlPullParser.TEXT -> {
-                        xmlSerializer.text(parser.text)
-                    }
-                }
-                eventType = parser.next()
-            }
-
+            // End the document and close the input and output file streams.
             xmlSerializer.endDocument()
             inputStream.close()
             outputStream.close()
+        }
+
+
+        // Helper Function to loop through the input file's XML content until reaching the end of the document and writes the note at the desired location.
+        private fun loopXMLDocument(eventType: Int, parser: XmlPullParser, xmlSerializer: XmlSerializer, currentNoteLocation: Int, noteLocation: Int, newNote: String) {
+            var eventType1 = eventType
+            var currentNoteLocation1 = currentNoteLocation
+            while (eventType1 != XmlPullParser.END_DOCUMENT) {
+                when (eventType1) {
+                    // Start of an XML tag.
+                    XmlPullParser.START_TAG -> {
+                        val tagName = parser.name
+
+                        // Write the start tag to the XmlSerializer.
+                        xmlSerializer.startTag(null, tagName)
+
+                        // Copy all attributes from the current XML tag to the XmlSerializer.
+                        copyTagToSerializer(parser, xmlSerializer)
+
+                        // If the current tag is a "note" tag, increment the currentNoteLocation.
+                        if (tagName == "note") {
+                            currentNoteLocation1++
+                        }
+                        // If the current tag is a "step" tag and the current note is at the desired location:
+                        // write the new note pitch to the XmlSerializer and skip the original note text.
+                        if (tagName == "step" && currentNoteLocation1 == noteLocation) {
+                            xmlSerializer.text(newNote)
+                            eventType1 = parser.next() // Skip the original note text
+                        }
+                    }
+                    // End of an XML tag.
+                    XmlPullParser.END_TAG -> {
+                        // Write the end tag to the XmlSerializer.
+                        xmlSerializer.endTag(null, parser.name)
+                    }
+
+                    // Text content between XML tags.
+                    XmlPullParser.TEXT -> {
+                        //Copy the text content to the XmlSerializer.
+                        xmlSerializer.text(parser.text)
+                    }
+                }
+                //Move to the next event in the input MusicXML file.
+                eventType1 = parser.next()
+            }
+        }
+
+        // Helper Function to copy all attributes from an XML tag to an XmlSerializer.
+        private fun copyTagToSerializer(parser: XmlPullParser, xmlSerializer: XmlSerializer) {
+            for (i in 0 until parser.attributeCount) {
+                xmlSerializer.attribute(
+                        null,
+                        parser.getAttributeName(i),
+                        parser.getAttributeValue(i)
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Added an Editor class which contains a public editNoteInMusicXML function which edits a note at a specific location in a musicXML file. This can be used in our library fragment to implement a simple editor.

Here is a more detailed description of the function: 

fun editNoteInMusicXML(outputFile: File, inputFile: File, noteLocation: Int, newNote: String)

- The caller must pass to the function an outputFile which is where the edited xml file is written to, (can be empty),
- the inputFile which is the file that needs to be edited,
- The location of the note to be edited
- the musicxml string for the new note. (if the newNote is not found, the output file is the same as the input file).