### PR TITLE
Fixing up the editor.

### DIFF
--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/activities/NotesDisplayedActivity.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/activities/NotesDisplayedActivity.kt
@@ -38,6 +38,7 @@ class NotesDisplayedActivity : AppCompatActivity() {
     var exceptionCaught: Boolean = false //Used in the unit tests to make sure the exception was handled
     private lateinit var noteSpinner: Spinner
     private lateinit var replaceNoteButton: Button
+    private lateinit var fileName : String
 
     /**
      * Initializes the activity and sets up the view.
@@ -89,7 +90,7 @@ class NotesDisplayedActivity : AppCompatActivity() {
         noteSpinner = findViewById(R.id.note_spinner)
 
         // Initialize the Spinner with an ArrayAdapter using an array of note choices.
-        val notesArray = arrayOf("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B") // modify this array as needed
+        val notesArray = arrayOf("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
         val spinnerAdapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, notesArray)
         noteSpinner.adapter = spinnerAdapter
 
@@ -101,7 +102,8 @@ class NotesDisplayedActivity : AppCompatActivity() {
             //print the current tick position
             val selectedNote = noteSpinner.selectedItem.toString()
             if (filePassed != null) {
-                editNote(filePassed, selectedNote)
+                val edited_file = editNote(filePassed,selectedNote)
+
             }
         }
     }
@@ -109,10 +111,11 @@ class NotesDisplayedActivity : AppCompatActivity() {
     //Required by the implementation of the library to work
     private fun openFile(uri: Uri) {
         var inMemoryObject = Score()
+        fileName = inMemoryObject.title
         try {
             val fileData = readFileData(uri)
             inMemoryObject = ScoreLoader.loadScoreFromBytes(fileData, _alphaTabView.settings)
-            Log.i("AlphaTab", "File loaded: ${inMemoryObject.title}")
+            Log.i("AlphaTab", "File loaded: $fileName")
         } catch (e: Exception) {
             exceptionCaught = true
             Log.e("AlphaTab", "Failed to load file: $e, ${e.stackTraceToString()}")
@@ -128,8 +131,6 @@ class NotesDisplayedActivity : AppCompatActivity() {
             Log.e("AlphaTab", "Failed to render file: $e, ${e.stackTraceToString()}")
             Toast.makeText(this, "Open File Failed", Toast.LENGTH_LONG).show()
         }
-
-
     }
 
     @ExperimentalContracts
@@ -171,26 +172,34 @@ class NotesDisplayedActivity : AppCompatActivity() {
      * @return The output file with the modified note.
      */
     private fun editNote(filePassed: String, newNote: String): File {
-
-        // Convert the filePassed URI string to a file and create a temporary file to store the modified musicXML
         val inputFileUri = Uri.parse(filePassed)
-        val inputFile = Companion.createTempFileFromUri(this, inputFileUri)
+        val inputFile = createTempFileFromUri(this, inputFileUri)
         val outputFile = File.createTempFile("temp_musicxml_modified", ".xml", cacheDir)
 
-        // Get the current tick position and convert it to a note location in the input musicXML file
         val tickPosition = _viewModel.currentTickPosition.value
         val noteLocation = Editor.getNoteCountWithinQuarterNotes(inputFile, tickPosition!!)
 
-        // Edit the note in the input musicXML file and write the modified content to the output file
         Editor.editNoteInMusicXML(outputFile, inputFile, noteLocation, newNote)
 
-        // Delete the input file since it's no longer needed and uses up storage space
-        inputFile.delete()
+        // Get the original file name and create a new file name for the edited file
+        val originalFileName = inputFileUri.lastPathSegment
+        val originalFileNameWithoutExtension = originalFileName?.substringBeforeLast('.')
+        val editedName = "edited_$originalFileNameWithoutExtension"
 
-        // Open the modified musicXML file in the app (refreshes the view)
+        // You have to specify where you want to save your edited file. Here, it's saved in the same directory as the original file
+        val editedFile = File(inputFile.parentFile, editedName)
+
+        // Copy the content of the outputFile to the editedFile
+        outputFile.copyTo(editedFile, overwrite = true)
+
+        val noteStorageManager = NotesStorageManager(this)
+
         openFile(Uri.fromFile(outputFile))
 
-        // Return the output file
+        noteStorageManager.writeNoteFile(editedName, outputFile.readText())
+
+        inputFile.delete()
+
         return outputFile
     }
 

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/activities/NotesDisplayedActivity.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/activities/NotesDisplayedActivity.kt
@@ -102,7 +102,7 @@ class NotesDisplayedActivity : AppCompatActivity() {
             //print the current tick position
             val selectedNote = noteSpinner.selectedItem.toString()
             if (filePassed != null) {
-                val edited_file = editNote(filePassed,selectedNote)
+                editNote(filePassed,selectedNote)
 
             }
         }
@@ -172,6 +172,7 @@ class NotesDisplayedActivity : AppCompatActivity() {
      * @return The output file with the modified note.
      */
     private fun editNote(filePassed: String, newNote: String): File {
+        val noteStorageManager = NotesStorageManager(this)
         val inputFileUri = Uri.parse(filePassed)
         val inputFile = createTempFileFromUri(this, inputFileUri)
         val outputFile = File.createTempFile("temp_musicxml_modified", ".xml", cacheDir)
@@ -184,19 +185,20 @@ class NotesDisplayedActivity : AppCompatActivity() {
         // Get the original file name and create a new file name for the edited file
         val originalFileName = inputFileUri.lastPathSegment
         val originalFileNameWithoutExtension = originalFileName?.substringBeforeLast('.')
-        val editedName = "edited_$originalFileNameWithoutExtension"
 
         // You have to specify where you want to save your edited file. Here, it's saved in the same directory as the original file
-        val editedFile = File(inputFile.parentFile, editedName)
+        val editedFile = originalFileNameWithoutExtension?.let { File(inputFile.parentFile, it) }
 
         // Copy the content of the outputFile to the editedFile
-        outputFile.copyTo(editedFile, overwrite = true)
-
-        val noteStorageManager = NotesStorageManager(this)
+        if (editedFile != null) {
+            outputFile.copyTo(editedFile, overwrite = true)
+        }
 
         openFile(Uri.fromFile(outputFile))
 
-        noteStorageManager.writeNoteFile(editedName, outputFile.readText())
+        if (originalFileNameWithoutExtension != null) {
+            noteStorageManager.writeNoteFile(originalFileNameWithoutExtension, outputFile.readText())
+        }
 
         inputFile.delete()
 

--- a/app/src/main/java/com/github/scribeWizTeam/scribewiz/util/Editor.kt
+++ b/app/src/main/java/com/github/scribeWizTeam/scribewiz/util/Editor.kt
@@ -28,6 +28,7 @@ class Editor {
             noteLocation: Int,
             newNote: String
         ) {
+
             // Initialize XmlPullParser for parsing the input MusicXML file.
             val parserFactory = XmlPullParserFactory.newInstance()
             val parser = parserFactory.newPullParser()

--- a/app/src/main/res/layout/notes_displayed_activity.xml
+++ b/app/src/main/res/layout/notes_displayed_activity.xml
@@ -37,10 +37,10 @@
         android:id="@+id/note_spinner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/replace_note_button"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintStart_toEndOf="@id/replace_note_button"
+        app:layout_constraintTop_toTopOf="@id/replace_note_button"
+        app:layout_constraintBottom_toBottomOf="@id/replace_note_button"
         android:layout_marginStart="12pt"
-        android:layout_marginTop="12pt"
         android:visibility="gone"
         />
 


### PR DESCRIPTION
- moved the spinner note options such that it sits next to the replace note button.

- fixed a file saving issue, where the edits were being discarded, the edited file is now saved as "edited_originalfilename"